### PR TITLE
Add Carousel component

### DIFF
--- a/src/demo/pages.tsx
+++ b/src/demo/pages.tsx
@@ -80,6 +80,7 @@ import DropdownExamples from "./pages/components/dropdown/exampleList";
 import ChartExamples from "./pages/data/chart/exampleList";
 import TooltipExamples from "./pages/components/tooltip/exampleList";
 import TextareaExamples from "./pages/forms/textarea/exampleList";
+import CarouselPage from "./pages/components/carousel/CarouselPage";
 
 interface Pages {
   name: string;
@@ -162,6 +163,11 @@ const componentsPages: Pages[] = [
     path: "/components/tooltip",
     element: <TooltipPage />,
   },
+  {
+    name: "carousel",
+    path: "/components/carousel",
+    element: <CarouselPage />
+  }
 ];
 
 const contentStylesPages: Pages[] = [

--- a/src/demo/pages/components/carousel/CarouselPage.tsx
+++ b/src/demo/pages/components/carousel/CarouselPage.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import BasicExample from "./examples/BasicExample";
+
+export default function CarouselPage(): JSX.Element {
+  return (<div className="container my-12 mx-5 w-auto">
+    {/* <!-- Section: Simple example --> */}
+    <section>
+      {/* <!-- Title --> */}
+      <h2
+        className="mb-5 mt-0 text-3xl font-semibold leading-normal"
+        id="basic"
+        data-te-spy-item
+      >
+        Basic Example
+      </h2>
+
+      {/* <!--Description --> */}
+      <p className="mb-3">Click the Carousel to start cycling through the carousel items (to be implemented).</p>
+      <BasicExample />
+    </section>
+  </div>)
+}

--- a/src/demo/pages/components/carousel/examples/BasicExample.tsx
+++ b/src/demo/pages/components/carousel/examples/BasicExample.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { TECarousel, TECarouselControl, TECarouselIndicators } from "tw-elements-react";
+
+export default function BasicExample(): JSX.Element {
+  return (<TECarousel
+    items={[
+      <img 
+        src="https://tecdn.b-cdn.net/img/Photos/Slides/img%20(15).jpg"
+        className="block w-full h-full object-cover"
+      />,
+      <img 
+        src="https://tecdn.b-cdn.net/img/Photos/Slides/img%20(22).jpg"
+        className="block w-full h-full object-cover"
+      />,
+      <img 
+        src="https://tecdn.b-cdn.net/img/Photos/Slides/img%20(23).jpg"
+        className="block w-full h-full object-cover"
+      />,
+    ]}
+    className="relative"
+  >
+    <TECarouselControl 
+      direction="prev"
+      className="flex w-[12%] items-center justify-center border-0 bg-none text-center text-white-strong opacity-50 transition-opacity duration-50 ease-[cubic-bezier(0.25,0.1,0.25,1.0)] hover:text-white-strong hover:no-underline hover:opacity-90 hover:outline-none focus:opacity-90 focus:outline-none motion-reduce:transition-none" 
+    >
+       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={'w-8 h-8'}>
+        <title>Previous</title>
+        <path fillRule="evenodd" d="M7.72 12.53a.75.75 0 010-1.06l7.5-7.5a.75.75 0 111.06 1.06L9.31 12l6.97 6.97a.75.75 0 11-1.06 1.06l-7.5-7.5z" clipRule="evenodd" />
+      </svg>
+    </TECarouselControl>
+    <TECarouselIndicators
+      className="list-none absolute w-full bottom-[5%] flex justify-center"
+      Component={() => (<span
+        role="presentation"
+        className="block relative mx-[3px] box-content h-[3px] w-[30px] flex-initial cursor-pointer border-0 border-y-[10px] border-solid border-transparent bg-white bg-clip-padding p-0 -indent-[999px] opacity-50 transition-opacity ease-[cubic-bezier(0.25,0.1,0.25,1.0)] duration-[600ms] motion-reduce:transition-none"
+      />)}
+      ActiveComponent={() => (<span
+        role="presentation"
+        className="block relative mx-[3px] box-content h-[3px] w-[30px] flex-initial cursor-pointer border-0 border-y-[10px] border-solid border-transparent bg-white bg-clip-padding p-0 -indent-[999px] opacity-100 transition-opacity ease-[cubic-bezier(0.25,0.1,0.25,1.0)] duration-[600ms] motion-reduce:transition-none"
+      />)}
+    />
+    <TECarouselControl
+      direction="next"
+      className="flex w-[12%] items-center justify-center border-0 bg-none text-center text-white-strong opacity-50 transition-opacity duration-50 ease-[cubic-bezier(0.25,0.1,0.25,1.0)] hover:text-white-strong hover:no-underline hover:opacity-90 hover:outline-none focus:opacity-90 focus:outline-none motion-reduce:transition-none"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={'w-8 h-8'}>
+        <title>Next</title>
+        <path fillRule="evenodd" d="M16.28 11.47a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 01-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 011.06-1.06l7.5 7.5z" clipRule="evenodd" />
+      </svg>
+    </TECarouselControl>
+  </TECarousel>)
+}

--- a/src/lib/components/Carousel/Carousel.tsx
+++ b/src/lib/components/Carousel/Carousel.tsx
@@ -1,0 +1,59 @@
+/*
+--------------------------------------------------------------------------
+Tailwind Elements React is an open-source UI kit of advanced components for TailwindCSS.
+Copyright © 2023 MDBootstrap.com
+
+Unless a custom, individually assigned license has been granted, this program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+In addition, a custom license may be available upon request, subject to the terms and conditions of that license. Please contact tailwind@mdbootstrap.com for more information on obtaining a custom license.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+--------------------------------------------------------------------------
+*/
+import React, { useMemo, useReducer } from "react";
+
+import { CarouselConfigContext } from "./context/CarouselConfigContext";
+import { CarouselDispatchContext } from "./context/CarouselDispatchContext";
+import { carouselReducer } from "./reducer/carouselReducer";
+import { CarouselStateContext } from "./context/CarouselStateContext";
+import CarouselContainer from "./CarouselContainer/CarouselContainer";
+import { CarouselConfig, CarouselProps } from "./types";
+
+const TECarousel: React.FC<CarouselProps & Partial<CarouselConfig>> = ({ 
+  interval = 4000,
+  touch = true,
+  keyboard = true,
+  items,
+  children,
+  ...props
+}) => {
+  const config: CarouselConfig = useMemo(() => ({
+    interval,
+    touch,
+    keyboard
+  }), [
+    interval,
+    touch,
+    keyboard
+  ]);
+
+  const [ state, dispatch ] = useReducer(carouselReducer, {
+    items: [],
+    activeItemId: 0,
+    desiredItemId: 0,
+    isRotating: false,
+  });
+
+  return (<CarouselConfigContext.Provider value={config}>
+    <CarouselDispatchContext.Provider value={dispatch}>
+      <CarouselStateContext.Provider value={state}>
+        <CarouselContainer
+          items={items}
+          {...props}
+        > 
+          {children}
+        </CarouselContainer>
+      </CarouselStateContext.Provider>
+    </CarouselDispatchContext.Provider>
+  </CarouselConfigContext.Provider>)
+}
+
+export default TECarousel;

--- a/src/lib/components/Carousel/Carousel.tsx
+++ b/src/lib/components/Carousel/Carousel.tsx
@@ -18,9 +18,10 @@ import CarouselContainer from "./CarouselContainer/CarouselContainer";
 import { CarouselConfig, CarouselProps } from "./types";
 
 const TECarousel: React.FC<CarouselProps & Partial<CarouselConfig>> = ({ 
-  interval = 4000,
+  interval = 5000,
   touch = true,
   keyboard = true,
+  ride = false,
   items,
   children,
   ...props
@@ -28,18 +29,20 @@ const TECarousel: React.FC<CarouselProps & Partial<CarouselConfig>> = ({
   const config: CarouselConfig = useMemo(() => ({
     interval,
     touch,
-    keyboard
+    keyboard,
+    ride
   }), [
     interval,
     touch,
-    keyboard
+    keyboard,
+    ride
   ]);
 
   const [ state, dispatch ] = useReducer(carouselReducer, {
     items: [],
     activeItemId: 0,
     desiredItemId: 0,
-    isRotating: false,
+    isRotating: ride === 'carousel',
   });
 
   return (<CarouselConfigContext.Provider value={config}>

--- a/src/lib/components/Carousel/CarouselContainer/CarouselContainer.tsx
+++ b/src/lib/components/Carousel/CarouselContainer/CarouselContainer.tsx
@@ -1,0 +1,124 @@
+import React, { TouchEventHandler, useEffect, useRef } from "react";
+
+import { 
+  carouselLoadItems,
+  carouselSlidePrev,
+  carouselSlideNext,
+  carouselStartRotation,
+  carouselStopRotation,
+  carouselTransitionEnd
+} from "../actions/creators";
+import { useCarouselConfig } from "../hooks/useCarouselConfig";
+import { useCarouselState } from "../hooks/useCarouselState";
+import { useCarouselDispatch } from "../hooks/useCarouselDispatch";
+import { CarouselContainerProps } from "./types";
+
+const TERCarouselContainer: React.FC<CarouselContainerProps> = ({ 
+  children, 
+  items, 
+  ...props
+}) => {
+  const { items: itemsData, activeItemId, desiredItemId, isRotating } = useCarouselState()
+  const { interval, touch } = useCarouselConfig()
+  const duration = 600
+  const dispatch = useCarouselDispatch()
+
+  useEffect(() => {
+    // We only care about the number of items here.
+    // Unless the carousel includes indicators, in which case we need to map indicators to slides, for a11y purposes.
+    // @see ./Indicators/TERCarouselIndicators.tsx
+    const itemsData = items.map(() => ({}))
+
+    dispatch(carouselLoadItems(itemsData))
+  }, [items, dispatch])
+
+  useEffect(() => {
+    if (isRotating && typeof interval === 'number' && desiredItemId === activeItemId) {
+      const autoRunTimeout = setTimeout(() => {
+        dispatch(carouselSlideNext())
+      }, interval)
+
+      return () => {
+        clearTimeout(autoRunTimeout)
+      }
+    }
+  }, [interval, activeItemId, desiredItemId, isRotating, dispatch])
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      dispatch(carouselTransitionEnd())
+    }, duration)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [desiredItemId, dispatch])
+
+  // Implementation from https://stackoverflow.com/a/70612770/8137604
+  const minSwipeDistance = 50
+  const touchStart = useRef<number|null>(null)
+  const touchEnd = useRef<number|null>(null)
+
+  const handleTouchStart: TouchEventHandler<HTMLLIElement> = (event) => {
+    touchEnd.current = null
+    touchStart.current = event.targetTouches[0].clientX
+  }
+
+  const handleTouchMove: TouchEventHandler<HTMLLIElement> = (event) => {
+    touchEnd.current = event.targetTouches[0].clientX
+  }
+
+  const handleTouchEnd: TouchEventHandler<HTMLLIElement> = () => {
+    if (!touchStart.current || !touchEnd.current) return
+
+    const distance = touchStart.current - touchEnd.current
+    const isLeftSwipe = distance > minSwipeDistance
+    const isRightSwipe = distance < -minSwipeDistance
+    if (isLeftSwipe) {
+      dispatch(carouselSlideNext())
+    } else if (isRightSwipe) {
+      dispatch(carouselSlidePrev())
+    }
+  }
+
+  return (<div
+    role="group"
+    aria-roledescription="carousel"
+    onFocus={() => dispatch(carouselStopRotation())}
+    onBlur={() => dispatch(carouselStartRotation())}
+    {...props}
+  >
+    <ol
+      aria-atomic="false"
+      aria-live={interval ? 'off' : 'polite'}
+      className="list-none relative w-full h-full overflow-hidden after:clear-both after:block after:content-['']"
+    >
+      {items.map((item, index, items) => {
+        const isActive = index === activeItemId
+        const isLeft = desiredItemId - 1 === index || desiredItemId === 0 && index === items.length - 1
+        const isRight = desiredItemId + 1 === index || desiredItemId === items.length - 1 && index === 0
+        const isDesired = index === desiredItemId
+        const metadata = itemsData[index]
+
+        return (<li
+          key={index}
+          id={metadata?.panelId}
+          role={metadata?.tabId ? 'tabpanel' : 'group'}
+          aria-roledescription="slide"
+          aria-label={metadata?.tabId ? undefined :  index + ' out of ' + items.length}
+          aria-labelledby={metadata?.tabId}
+          className={`relative float-left -mr-[100%] ${isActive || isDesired ? 'visible' : 'invisible' } ${isLeft ? '-translate-x-full' : '' } ${isRight ? 'translate-x-full' : '' } ${isDesired ? 'translate-x-0' : '' } w-full h-full transition-transform ease-in-out`}
+          style={{ backfaceVisibility: 'hidden', transitionDuration: duration + 'ms' }}
+          onTouchStart={touch ? handleTouchStart : undefined}
+          onTouchMove={touch ? handleTouchMove : undefined}
+          onTouchEnd={touch ? handleTouchEnd : undefined}
+        >
+          {item}
+        </li>)
+      })}
+    </ol>
+    {children}
+  </div>)
+}
+
+export default TERCarouselContainer;

--- a/src/lib/components/Carousel/CarouselContainer/CarouselContainer.tsx
+++ b/src/lib/components/Carousel/CarouselContainer/CarouselContainer.tsx
@@ -15,11 +15,12 @@ import { CarouselContainerProps } from "./types";
 
 const TERCarouselContainer: React.FC<CarouselContainerProps> = ({ 
   children, 
-  items, 
+  items,
+  renderItem,
   ...props
 }) => {
   const { items: itemsData, activeItemId, desiredItemId, isRotating } = useCarouselState()
-  const { interval, touch } = useCarouselConfig()
+  const { interval, touch, ride } = useCarouselConfig()
   const duration = 600
   const dispatch = useCarouselDispatch()
 
@@ -33,7 +34,7 @@ const TERCarouselContainer: React.FC<CarouselContainerProps> = ({
   }, [items, dispatch])
 
   useEffect(() => {
-    if (isRotating && typeof interval === 'number' && desiredItemId === activeItemId) {
+    if (ride && isRotating && typeof interval === 'number' && desiredItemId === activeItemId) {
       const autoRunTimeout = setTimeout(() => {
         dispatch(carouselSlideNext())
       }, interval)
@@ -42,7 +43,7 @@ const TERCarouselContainer: React.FC<CarouselContainerProps> = ({
         clearTimeout(autoRunTimeout)
       }
     }
-  }, [interval, activeItemId, desiredItemId, isRotating, dispatch])
+  }, [ride, interval, activeItemId, desiredItemId, isRotating, dispatch])
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -113,7 +114,10 @@ const TERCarouselContainer: React.FC<CarouselContainerProps> = ({
           onTouchMove={touch ? handleTouchMove : undefined}
           onTouchEnd={touch ? handleTouchEnd : undefined}
         >
-          {item}
+          {renderItem 
+            ? renderItem({ children: item })
+            : item
+          }
         </li>)
       })}
     </ol>

--- a/src/lib/components/Carousel/CarouselContainer/types.ts
+++ b/src/lib/components/Carousel/CarouselContainer/types.ts
@@ -4,6 +4,7 @@ import { BaseComponent } from "../../../types/baseComponent";
 
 interface CarouselContainerProps extends BaseComponent {
   items: React.ReactNode[];
+  renderItem: (props: React.PropsWithChildren<any>) => JSX.Element
 }
 
 export { CarouselContainerProps };

--- a/src/lib/components/Carousel/CarouselContainer/types.ts
+++ b/src/lib/components/Carousel/CarouselContainer/types.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+import { BaseComponent } from "../../../types/baseComponent";
+
+interface CarouselContainerProps extends BaseComponent {
+  items: React.ReactNode[];
+}
+
+export { CarouselContainerProps };

--- a/src/lib/components/Carousel/CarouselControls/CarouselControls.tsx
+++ b/src/lib/components/Carousel/CarouselControls/CarouselControls.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { carouselSlideNext, carouselSlidePrev } from "../actions/creators";
+import { useCarouselDispatch } from "../hooks/useCarouselDispatch";
+import { CarouselControlProps } from "./types";
+import clsx from "clsx";
+
+const TECarouselControl: React.FC<CarouselControlProps> = ({ 
+  children,
+  direction, 
+  className, 
+  ...props
+}) => {
+  const dispatch = useCarouselDispatch()
+
+  const handleClick = () => {
+    dispatch(direction === 'prev' ? carouselSlidePrev() : carouselSlideNext())
+  }
+
+  return (<button
+    type="button"
+    onClick={handleClick}
+    className={clsx(
+      'absolute bottom-0 top-0 z-10',
+      direction === 'prev' ? 'left-0' : 'right-0',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </button>)
+}
+
+export default TECarouselControl;

--- a/src/lib/components/Carousel/CarouselControls/types.ts
+++ b/src/lib/components/Carousel/CarouselControls/types.ts
@@ -1,0 +1,7 @@
+import { BaseComponent } from "../../../types/baseComponent";
+
+interface CarouselControlProps extends BaseComponent {
+  direction: 'prev' | 'next';
+}
+
+export { CarouselControlProps };

--- a/src/lib/components/Carousel/CarouselIndicators/CarouseIndicators.tsx
+++ b/src/lib/components/Carousel/CarouselIndicators/CarouseIndicators.tsx
@@ -1,0 +1,87 @@
+import React, { KeyboardEventHandler, useEffect, useId, useRef } from "react";
+
+import { 
+  carouselJumpTo,
+  carouselUpdateItems,
+  carouselSlidePrev,
+  carouselSlideNext,
+} from "../actions/creators";
+import { useCarouselConfig } from "../hooks/useCarouselConfig";
+import { CarouselIndicatorsProps } from "./types";
+import { useCarouselState } from "../hooks/useCarouselState";
+import { useCarouselDispatch } from "../hooks/useCarouselDispatch";
+
+const TECarouselIndicators: React.FC<CarouselIndicatorsProps> = ({ 
+  Component,
+  ActiveComponent,
+  ...props
+}) => {
+  const { keyboard } = useCarouselConfig()
+  const { items, activeItemId } = useCarouselState()
+  const dispatch = useCarouselDispatch()
+
+  const createHandler = (index: number) => {
+    return () => dispatch(carouselJumpTo(index))
+  }
+
+  const tablistId = useId()
+
+  useEffect(() => {
+    const newItems = items.map(
+      (item, index) => ({ 
+        tabId: tablistId + '-tab-' + index,
+        panelId: tablistId + '-panel-' + index, 
+        ...item 
+      })
+    )
+    dispatch(carouselUpdateItems(newItems))
+  }, [dispatch, tablistId]) // Do not include items in the dependency array, as it will cause an infinite render loop.
+
+  const listRef = useRef<HTMLOListElement | null>(null)
+
+  const handleKeyDown: KeyboardEventHandler = (event) => {
+    switch (event.key) { 
+      case 'ArrowLeft':
+        event.preventDefault();
+        dispatch(carouselSlidePrev());
+        (listRef.current?.children[(activeItemId || items.length) - 1] as HTMLLIElement).focus();
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        dispatch(carouselSlideNext());
+        (listRef.current?.children[(activeItemId + 1) % items.length] as HTMLLIElement).focus();
+        break;
+    } 
+  }
+
+  return (<ol 
+    ref={listRef}
+    role="tablist"
+    onKeyDown={keyboard ? handleKeyDown : undefined}
+    {...props}
+  >
+    {items.map(
+      (item, index) => {
+        const isActiveTab = index === activeItemId
+
+        return (<li key={index}
+            id={item.tabId}
+            tabIndex={isActiveTab ? 0 : -1}
+            role="tab"
+            aria-controls={item.panelId}
+            aria-selected={isActiveTab}
+            aria-label={'Slide ' + (index + 1)}
+            onClick={createHandler(index)}
+          >
+            {isActiveTab
+              ? <ActiveComponent />
+              : <Component />
+            }
+          </li>
+        )
+      }
+    )}
+  </ol>)
+}
+
+export { TECarouselIndicators };

--- a/src/lib/components/Carousel/CarouselIndicators/types.tsx
+++ b/src/lib/components/Carousel/CarouselIndicators/types.tsx
@@ -1,0 +1,10 @@
+import { JSXElementConstructor } from "react";
+
+import { BaseComponent } from "../../../types/baseComponent";
+
+interface CarouselIndicatorsProps extends BaseComponent {
+  Component: JSXElementConstructor<unknown>,
+  ActiveComponent: JSXElementConstructor<unknown>
+}
+
+export { CarouselIndicatorsProps };

--- a/src/lib/components/Carousel/actions/creators.ts
+++ b/src/lib/components/Carousel/actions/creators.ts
@@ -1,0 +1,43 @@
+import {
+  CarouselActionJumpTo,
+  CarouselActionLoadItems,
+  CarouselActionSlideNext,
+  CarouselActionSlidePrev,
+  CarouselActionStartRotation,
+  CarouselActionStopRotation,
+  CarouselActionTransitionEnd,
+  CarouselActionType,
+  CarouselActionUpdateItems
+} from "./types";
+
+export function carouselLoadItems(items: CarouselItemData[]): CarouselActionLoadItems {
+  return { type: CarouselActionType.LoadItems, payload: items };
+}
+
+export function carouselUpdateItems(items: CarouselItemData[]): CarouselActionUpdateItems {
+  return { type: CarouselActionType.UpdateItems, payload: items };
+}
+
+export function carouselSlidePrev(): CarouselActionSlidePrev {
+  return { type: CarouselActionType.SlidePrev };
+}
+
+export function carouselSlideNext(): CarouselActionSlideNext {
+  return { type: CarouselActionType.SlideNext };
+}
+
+export function carouselTransitionEnd(): CarouselActionTransitionEnd {
+  return { type: CarouselActionType.TransitionEnd };
+}
+
+export function carouselJumpTo(index: number): CarouselActionJumpTo {
+  return { type: CarouselActionType.JumpTo, payload: index };
+}
+
+export function carouselStartRotation(): CarouselActionStartRotation {
+  return { type: CarouselActionType.StartRotation };
+}
+
+export function carouselStopRotation(): CarouselActionStopRotation {
+  return { type: CarouselActionType.StopRotation };
+}

--- a/src/lib/components/Carousel/actions/types.ts
+++ b/src/lib/components/Carousel/actions/types.ts
@@ -1,0 +1,55 @@
+export enum CarouselActionType {
+  LoadItems,
+  UpdateItems,
+  SlidePrev,
+  SlideNext,
+  TransitionEnd,
+  StartRotation,
+  StopRotation,
+  JumpTo
+}
+
+export interface CarouselActionLoadItems {
+  readonly type: CarouselActionType.LoadItems;
+  payload: CarouselItemData[];
+}
+
+export interface CarouselActionUpdateItems {
+  readonly type: CarouselActionType.UpdateItems;
+  payload: CarouselItemData[];
+}
+
+export interface CarouselActionSlidePrev {
+  readonly type: CarouselActionType.SlidePrev;
+}
+
+export interface CarouselActionSlideNext {
+  readonly type: CarouselActionType.SlideNext;
+}
+
+export interface CarouselActionTransitionEnd {
+  readonly type: CarouselActionType.TransitionEnd;
+}
+
+export interface CarouselActionStartRotation {
+  readonly type: CarouselActionType.StartRotation;
+}
+
+export interface CarouselActionStopRotation {
+  readonly type: CarouselActionType.StopRotation;
+}
+
+export interface CarouselActionJumpTo {
+  readonly type: CarouselActionType.JumpTo;
+  payload: number;
+}
+
+export type CarouselAction = 
+  CarouselActionLoadItems |
+  CarouselActionUpdateItems |
+  CarouselActionSlidePrev |
+  CarouselActionSlideNext |
+  CarouselActionTransitionEnd |
+  CarouselActionStartRotation |
+  CarouselActionStopRotation |
+  CarouselActionJumpTo

--- a/src/lib/components/Carousel/context/CarouselConfigContext.tsx
+++ b/src/lib/components/Carousel/context/CarouselConfigContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+import { CarouselConfig } from "../types";
+
+const CarouselConfigContext = createContext<CarouselConfig>({
+  interval: 4000,
+  touch: true,
+  keyboard: true,
+});
+
+export { CarouselConfigContext };

--- a/src/lib/components/Carousel/context/CarouselConfigContext.tsx
+++ b/src/lib/components/Carousel/context/CarouselConfigContext.tsx
@@ -3,9 +3,10 @@ import { createContext } from "react";
 import { CarouselConfig } from "../types";
 
 const CarouselConfigContext = createContext<CarouselConfig>({
-  interval: 4000,
+  interval: 5000,
   touch: true,
   keyboard: true,
+  ride: false,
 });
 
 export { CarouselConfigContext };

--- a/src/lib/components/Carousel/context/CarouselDispatchContext.tsx
+++ b/src/lib/components/Carousel/context/CarouselDispatchContext.tsx
@@ -1,0 +1,5 @@
+import { Dispatch, createContext } from "react";
+
+const CarouselDispatchContext = createContext<Dispatch<CarouselAction>|undefined>(undefined);
+
+export { CarouselDispatchContext };

--- a/src/lib/components/Carousel/context/CarouselStateContext.tsx
+++ b/src/lib/components/Carousel/context/CarouselStateContext.tsx
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+const CarouselStateContext = createContext<CarouselState>({
+  items: [],
+  activeItemId: 0,
+  desiredItemId: 0,
+  isRotating: false,
+})
+
+export { CarouselStateContext };

--- a/src/lib/components/Carousel/hooks/useCarouselConfig.ts
+++ b/src/lib/components/Carousel/hooks/useCarouselConfig.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { CarouselConfigContext } from "../context/CarouselConfigContext";
+
+export function useCarouselConfig() {
+  const carouselConfig = useContext(CarouselConfigContext);
+
+  if (!carouselConfig) {
+    throw new Error('Carousel subcomponents must be used within a Carousel component.');
+  }
+
+  return carouselConfig;
+}

--- a/src/lib/components/Carousel/hooks/useCarouselDispatch.tsx
+++ b/src/lib/components/Carousel/hooks/useCarouselDispatch.tsx
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { CarouselDispatchContext } from "../context/CarouselDispatchContext";
+
+export function useCarouselDispatch() {
+  const carouselDispatch = useContext(CarouselDispatchContext);
+
+  if (!carouselDispatch) {
+    throw new Error('Carousel subcomponents must be used within a Carousel component.');
+  }
+
+  return carouselDispatch;
+}

--- a/src/lib/components/Carousel/hooks/useCarouselState.ts
+++ b/src/lib/components/Carousel/hooks/useCarouselState.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { CarouselStateContext } from "../context/CarouselStateContext";
+
+export function useCarouselState() {
+  const carouselState = useContext(CarouselStateContext);
+
+  if (!carouselState) {
+    throw new Error('Carousel subcomponents must be used within a Carousel component.');
+  }
+
+  return carouselState;
+}

--- a/src/lib/components/Carousel/reducer/carouselReducer.ts
+++ b/src/lib/components/Carousel/reducer/carouselReducer.ts
@@ -1,0 +1,52 @@
+import { CarouselAction, CarouselActionType } from "../actions/types"
+
+export function carouselReducer(state: CarouselState, action: CarouselAction): CarouselState {
+  switch(action.type) {
+    case CarouselActionType.LoadItems:
+      return {
+        ...state,
+        items: action.payload,
+        activeItemId: 0,
+        desiredItemId: 0,
+      }
+    case CarouselActionType.UpdateItems:
+      return {
+        ...state,
+        items: action.payload,
+      }
+    case CarouselActionType.SlidePrev:
+      return {
+        ...state,
+        desiredItemId: (state.activeItemId || state.items.length) - 1,
+      }
+    case CarouselActionType.SlideNext:
+      return {
+        ...state,
+        desiredItemId: (state.activeItemId + 1) % state.items.length
+      }
+    case CarouselActionType.TransitionEnd:
+      return {
+        ...state,
+        activeItemId: state.desiredItemId
+      }
+    case CarouselActionType.JumpTo:
+      return action.payload < state.items.length && action.payload >= 0
+        ? {
+          ...state,
+          desiredItemId: action.payload
+        }
+        : state
+    case CarouselActionType.StartRotation:
+      return {
+        ...state,
+        isRotating: true
+      }
+    case CarouselActionType.StopRotation:
+      return {
+        ...state,
+        isRotating: false
+      }
+    default:
+      return state
+  }
+}

--- a/src/lib/components/Carousel/reducer/types.ts
+++ b/src/lib/components/Carousel/reducer/types.ts
@@ -1,0 +1,11 @@
+interface CarouselItemData {
+  tabId?: string;
+  panelId?: string;
+}
+
+interface CarouselState {
+  items: CarouselItemData[];
+  activeItemId: number;
+  desiredItemId: number;
+  isRotating: boolean;
+}

--- a/src/lib/components/Carousel/types.tsx
+++ b/src/lib/components/Carousel/types.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { BaseComponent } from "../../types/baseComponent";
+
+interface CarouselConfig {
+  interval: number;
+  touch: boolean;
+  keyboard: boolean;
+}
+
+interface CarouselProps extends BaseComponent {
+  items: React.ReactNode[]
+}
+
+export { CarouselConfig, CarouselProps };

--- a/src/lib/components/Carousel/types.tsx
+++ b/src/lib/components/Carousel/types.tsx
@@ -6,6 +6,7 @@ interface CarouselConfig {
   interval: number;
   touch: boolean;
   keyboard: boolean;
+  ride: 'carousel'|boolean;
 }
 
 interface CarouselProps extends BaseComponent {

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -21,6 +21,9 @@ import TEDropdownItem from "./components/Dropdown/DropdownItem/DropdownItem";
 import TEChart from "./data/Chart/Chart";
 import TETooltip from "./components/Tooltip/Tooltip";
 import TETextarea from "./forms/Textarea/Textarea";
+import TECarousel from "./components/Carousel/Carousel";
+import TECarouselControl from "./components/Carousel/CarouselControls/CarouselControls";
+import { TECarouselIndicators } from "./components/Carousel/CarouselIndicators/CarouseIndicators";
 
 export {
   TECollapse,
@@ -46,4 +49,7 @@ export {
   TEChart,
   TETooltip,
   TETextarea,
+  TECarousel,
+  TECarouselControl,
+  TECarouselIndicators
 };


### PR DESCRIPTION
## Changes

This PR aims to add the a Carousel component similar to the [one from the Tailwind Elements library](https://tailwind-elements.com/docs/standard/components/carousel/).

It also aims to implements the [Carousel Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) from the WAI-ARIA Authoring Practice guide.

This PR is in draft mode in order to start a discussion related to #12 

## To Do (not exhaustive)

- [ ] Support all the options from [TE Carousel API](https://tailwind-elements.com/docs/standard/components/carousel/#docsTabsAPI)
  - [ ] pause
  - [ ] ride
  - [ ] wrap
- [ ] ? Implement a Rotation Control (as described by WAI-ARIA)
- [ ] ? Exports the context providers for programmtically interacting with a Carousel component 
- [ ] ? Supports the fade animation (alternative option: see below)

## Going further

- [ ] ? Extract the swipe controls in a custom hook for usage in other components
- [ ] ? Use the future Animation component to handle slide transition